### PR TITLE
Change nginx_version scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An Ansible role to install Nginx.
 
 ## Role Variables
 
-- `nginx_version` - Nginx version
+- `nginx_version` - Nginx version (default: `stable`, valid options are: `stable` or `development`)
 - `nginx_delete_default_site` - Whether or not to delete the default Nginx site (default: `False`)
 
 ## Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-nginx_version: "1.6.2-2+trusty0"
+nginx_version: "stable"
 nginx_delete_default_site: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,20 @@
 ---
-- name: Configure the Nginx (Stable) PPA
-  apt_repository: repo=ppa:nginx/stable state=present
+- name: Configure the Nginx PPA
+  apt_repository: repo=ppa:nginx/{{ nginx_version }} state=present
 
 - name: Install Nginx
-  apt: pkg=nginx={{ nginx_version }} state=present
+  apt: pkg=nginx state=present
 
 - name: Delete default site
   file: path=/etc/nginx/sites-enabled/default state=absent
+  register: delete_default_site
   when: nginx_delete_default_site | bool
   notify:
     - Restart Nginx
+
+- name: Delete default web root
+  file: path=/var/www/html state=absent
+  when: nginx_delete_default_site | bool and delete_default_site | changed
 
 - name: Configure Nginx
   template: src=nginx.conf.j2 dest=/etc/nginx/nginx.conf


### PR DESCRIPTION
This changeset changes the version scheme for the Nginx installation from package version numbers to PPA type.

Whenever a new package is released for Nginx in the PPA used by this role, it doesn't get added to the repository, instead it replaces the existing package. This becomes problematic if you are attempting to pin
package versions.

The best alternative I could come up with was to pin just the repository type (development or stable). This way, if package version number `1.6.2-2+trusty0` gets replaced with `1.6.2-4+trusty0`, the role doesn't break.
