### PR TITLE
Fix Nginx bug in logrotate postrotate script

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,14 @@
   file: path=/var/www/html state=absent
   when: nginx_delete_default_site | bool and delete_default_site | changed
 
+- name: Check Nginx Upstart service definition exists
+  stat: path=/etc/init/nginx.conf
+  register: nginx_upstart
+
+- name: Configure Nginx log rotation
+  template: src=logrotate_nginx.j2 dest=/etc/logrotate.d/nginx
+  when: nginx_upstart.stat.exists
+
 - name: Configure Nginx
   template: src=nginx.conf.j2 dest=/etc/nginx/nginx.conf
   notify:

--- a/templates/logrotate_nginx.j2
+++ b/templates/logrotate_nginx.j2
@@ -1,0 +1,18 @@
+/var/log/nginx/*.log {
+	weekly
+	missingok
+	rotate 52
+	compress
+	delaycompress
+	notifempty
+	create 0640 www-data adm
+	sharedscripts
+	prerotate
+		if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
+			run-parts /etc/logrotate.d/httpd-prerotate; \
+		fi \
+	endscript
+	postrotate
+		service nginx rotate >/dev/null 2>&1
+	endscript
+}


### PR DESCRIPTION
The default `logrotate` `postrotate` script for Nginx attempts to make use of `invoke-rc.d` to target the `rotate` subcommand on the Nginx `init.d` script. This fails with the following error because now there an Upstart script for Nginx exists:

```
initctl: invalid command: rotate
Try `initctl --help' for more information.
invoke-rc.d: initscript nginx, action "rotate" failed.
```

This changeset adjusts the `postrotate` script to use the `service` command vs. `invoke-rc.d`, which allows the log rotation to complete successfully.

See also: https://bugs.launchpad.net/nginx/+bug/1450770

---

To test, I used the following steps to ensure that Nginx is writing to the newly created log file vs. the old one that was rotated:

```bash
$ sudo su -c 'cat /var/log/lastlog >> /var/log/nginx/access.log'
$ sudo vim /etc/logrotate.d/nginx # Add a `size 1k` directive
$ sudo logrotate /etc/logrotate.d/nginx
$ sudo lsof -p 2961 | grep log
nginx   2961 root    2w   REG                8,1       60 139630 /var/log/nginx/error.log
nginx   2961 root    4w   REG                8,1       60 139630 /var/log/nginx/error.log
nginx   2961 root    9w   REG                8,1   292584 139418 /var/log/nginx/access.log
```