### PR TITLE
Disable Nginx server tokens

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -13,6 +13,8 @@ http {
 	keepalive_timeout 65;
 	types_hash_max_size 2048;
 
+	server_tokens off;
+
 	include /etc/nginx/mime.types;
 	default_type application/octet-stream;
 


### PR DESCRIPTION
Eliminate reporting Nginx version using via the Server header.

---

**Testing**

Bring up the example VM and inspect the `Server` header in an HTTP request:

```bash
$ cd example
$ vagrant up
$ curl -I localhost:8080/
HTTP/1.1 200 OK
Server: nginx
Date: Tue, 12 Jul 2016 14:53:28 GMT
Content-Type: text/html
Content-Length: 612
Last-Modified: Tue, 12 Jul 2016 14:48:25 GMT
Connection: keep-alive
Vary: Accept-Encoding
ETag: "57850339-264"
Accept-Ranges: bytes
```

Note that the `Server` header only references `nginx` and no specific version.