### PR TITLE
Explicitly install full version of Nginx package

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   apt_repository: repo=ppa:nginx/{{ nginx_version }} state=present
 
 - name: Install Nginx
-  apt: pkg=nginx state=present
+  apt: pkg=nginx-full state=present
 
 - name: Delete default site
   file: path=/etc/nginx/sites-enabled/default state=absent


### PR DESCRIPTION
To remove any ambiguity, install the `nginx-full` package because it enables most of the core included modules that are standard and optional in the Nginx source tarball.

See also: http://askubuntu.com/a/556382

---

**Testing**

Ensure that provisioning still work after the introduced changes:

```bash
$ cd examples
$ vagrant up
```