### PR TITLE
Add correct MIME Type for gzipping javascript

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -27,7 +27,7 @@ http {
 	gzip_comp_level 6;
 	gzip_buffers 16 8k;
 	gzip_http_version 1.1;
-	gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+	gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript;
 
 	include /etc/nginx/conf.d/*.conf;
 	include /etc/nginx/sites-enabled/*;


### PR DESCRIPTION
## Overview

Javascript files are requested with a Content-Type of `application/javascript` which was absent from the gzip configuration, therefore javascript files were being served uncompressed.  The existing MIME Type which targeted javascript, `text/javascript`, is [meant to be obsolete](https://www.maxcdn.com/one/tutorial/mime-types/) but was left to support older clients.

I tested this change by applying it to MMW, which provided these before and after `Content-Encoding: gzip` headers for a JS file served by nginx, and corresponding byte reduction:

#### Before
![screenshot from 2017-09-01 09 15 41](https://user-images.githubusercontent.com/1014341/29971428-290727ee-8ef6-11e7-98f9-ba8ef5e458e9.png)


#### After
![screenshot from 2017-09-01 09 12 09](https://user-images.githubusercontent.com/1014341/29971314-cf9cfcb0-8ef5-11e7-8e64-7aaa42dd977e.png)
